### PR TITLE
Feature of CLI Export Image Command

### DIFF
--- a/src/main/java/codecain/CommandLineInterface/Model/DisplayHelper.java
+++ b/src/main/java/codecain/CommandLineInterface/Model/DisplayHelper.java
@@ -52,6 +52,7 @@ public class DisplayHelper {
             Other Commands:
             1. help                                - Shows this help message.
             2. exit                                - Exits the application.
+            3. export                              - Exports the UML diagram to a PNG file. 
 
             Examples:
             - add class Person
@@ -73,6 +74,7 @@ public class DisplayHelper {
             - list relationships
             - help
             - exit
+            - export ProjectFile
 
             """;
     }

--- a/src/main/java/codecain/GraphicalUserInterface/Controller/Controller.java
+++ b/src/main/java/codecain/GraphicalUserInterface/Controller/Controller.java
@@ -7,36 +7,26 @@ import java.util.Optional;
 import codecain.BackendCode.Model.Relationship;
 import codecain.BackendCode.Model.SaveManager;
 import codecain.BackendCode.Model.UMLClass;
-
-import codecain.GraphicalUserInterface.Model.*;
-import codecain.GraphicalUserInterface.View.PositionUtils;
-import codecain.GraphicalUserInterface.View.AlertHelper;
-
 import codecain.GraphicalUserInterface.Model.ArrowManager;
 import codecain.GraphicalUserInterface.Model.ClassManager;
+import codecain.GraphicalUserInterface.Model.ExportImage;
 import codecain.GraphicalUserInterface.Model.FieldManager;
 import codecain.GraphicalUserInterface.Model.MethodManager;
 import codecain.GraphicalUserInterface.Model.ParameterManager;
 import codecain.GraphicalUserInterface.Model.RelationshipManager;
-
 import codecain.GraphicalUserInterface.View.ClassNode;
 import codecain.GraphicalUserInterface.View.PositionUtils;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
-import javafx.scene.control.*;
-import javafx.scene.image.WritableImage;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextInputDialog;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Pane;
 import javafx.stage.FileChooser;
 import javafx.stage.Window;
-
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Optional;
-
-import javax.imageio.ImageIO;
-import javafx.embed.swing.SwingFXUtils;
 
 /**
  * Controller class for managing user interactions with the UML editor GUI.
@@ -421,6 +411,15 @@ public class Controller {
         } else {
             System.out.println("Exit canceled.");
         }
+    }
+
+    /**
+     * Gets the node container for the UML diagram.
+     *
+     * @return The AnchorPane containing the UML diagram nodes.
+     */
+    public Pane getNodeContainer() {
+        return nodeContainer;
     }
 
 }

--- a/src/main/java/codecain/GraphicalUserInterface/View/MenuGUI.java
+++ b/src/main/java/codecain/GraphicalUserInterface/View/MenuGUI.java
@@ -10,55 +10,94 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 
+
+/**
+ * The MenuGUI class serves as the main menu for the Code Cain UML Editor.
+ * It provides options to launch the Command Line Interface (CLI) or the
+ * Graphical User Interface (GUI) for managing UML diagrams.
+ */
 public class MenuGUI extends Application {
 
+    /**
+     * Initializes and displays the main menu window with options to launch the CLI or GUI.
+     *
+     * @param primaryStage The primary stage for this application.
+     */
     @Override
     public void start(Stage primaryStage) {
-        // Welcome message
         Text welcomeText = new Text("Welcome to Code Cain UML Editor");
         welcomeText.setFont(Font.font("Arial", 20));
 
-        // CLI Button
         Button cliButton = new Button("CLI");
         cliButton.setOnAction(event -> {
-            try {
-                Stage cliStage = new Stage();
-                CLI cli = new CLI();
-                cli.start(cliStage); // Launch CLI directly
-                primaryStage.hide(); // Hide the main menu
-
-                // Show the main menu again when the CLI stage is closed
-                cliStage.setOnCloseRequest(event1 -> primaryStage.show());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            launchCLI(primaryStage); 
         });
 
-        // GUI Button
         Button guiButton = new Button("Graphical Interface");
         guiButton.setOnAction(event -> {
-            try {
-                Stage guiStage = new Stage();
-                GraphicalInterfaceJavaFX gui = new GraphicalInterfaceJavaFX();
-                gui.start(guiStage); // Launch GUI directly
-                primaryStage.hide(); // Hide the main menu
-
-                // Show the main menu again when the GUI stage is closed
-                guiStage.setOnCloseRequest(event1 -> primaryStage.show());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            launchGraphicalInterface(primaryStage);
         });
-
-        // Layout setup
         VBox layout = new VBox(20, welcomeText, cliButton, guiButton);
-        layout.setAlignment(Pos.CENTER); // Center everything horizontally and vertically
-
-        // Scene setup
+        layout.setAlignment(Pos.CENTER);
         Scene scene = new Scene(layout, 400, 300);
         primaryStage.setTitle("UML Manager");
         primaryStage.setScene(scene);
         primaryStage.show();
+    }
+
+    /**
+     * Launches the Command Line Interface (CLI) in a new stage.
+     * The main menu is hidden while the CLI window is active and shown again
+     * when the CLI window is closed.
+     *
+     * @param parentStage The main menu stage to hide while the CLI is active.
+     */
+    public static void launchCLI(Stage parentStage) {
+        try {
+            Stage cliStage = new Stage();
+            CLI cli = new CLI();
+            cli.start(cliStage);
+            if (parentStage != null) parentStage.hide(); // Hide the main menu
+
+            cliStage.setOnCloseRequest(event1 -> {
+                if (parentStage != null) parentStage.show();
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Launches the Graphical User Interface (GUI) in a new stage.
+     * The main menu is hidden while the GUI window is active and shown again
+     * when the GUI window is closed.
+     *
+     * @param parentStage The main menu stage to hide while the GUI is active.
+     */
+    public static void launchGraphicalInterface(Stage parentStage) {
+        try {
+            Stage guiStage = new Stage();
+            GraphicalInterfaceJavaFX gui = new GraphicalInterfaceJavaFX();
+            gui.start(guiStage);
+            if (parentStage != null) parentStage.hide();
+
+            guiStage.setOnCloseRequest(event1 -> {
+                if (parentStage != null) parentStage.show();
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Hides the specified stage.
+     * 
+     * @param stage The stage to hide.
+     */
+    public static void hideStage(Stage stage) {
+        if (stage != null) {
+            stage.hide();
+        }
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Cleaned up MenuGUI so its easier to call on the launch either window commands (Should allow us to do some of the extra credit stuff easier)

Added a Get Anchor Pane method in controller

Added Export Image command to CLI that puts the file path in root by opening up the GUI in the background and grabbing its node container.

Use the export command in CLI for usage.